### PR TITLE
fix: publish build folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
   "author": "Michael J. Zoidl <github@michaelzoidl.com>",
   "license": "MIT",
   "main": "index.js",
+  "files": [
+    "index.js",
+    "build"
+  ],
   "repository": "michaelzoidl/babel-root-import",
   "scripts": {
     "test": "mocha test/*.spec.js --require config/mocha.js --compilers js:babel-core/register",


### PR DESCRIPTION
the build folder is not published
See: https://npmcdn.com/babel-root-import@3.0.0/build/index.js