### PR TITLE
feat(plugin): use relative paths, support "%/" in rootPathSuffix to r…

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,10 +14,12 @@
     "test": "mocha test/*.spec.js --require config/mocha.js --compilers js:babel-core/register",
     "test-watch": "mocha test/*.spec.js --require config/mocha.js --compilers js:babel-core/register --watch",
     "lint-js": "eslint plugin",
-    "compile": "babel -d build/ plugin/"
+    "compile": "$(npm bin -g)/babel -d build/ plugin/",
+    "compile-watch": "$(npm bin -g)/babel -d build/ plugin/ -w"
   },
   "dependencies": {
-    "babel": "^6.1.18"
+    "babel": "^6.1.18",
+    "find-pkg": "^0.1.0"
   },
   "devDependencies": {
     "babel-core": "^6.2.1",

--- a/plugin/helper.js
+++ b/plugin/helper.js
@@ -1,12 +1,23 @@
-export default function(path) {
+var dirname = require('path').dirname;
+var relative = require('path').relative;
+var findPkg = require('find-pkg');
+
+export default function() {
   class BabelRootImportHelper {
 
     root = global.rootPath || process.cwd()
 
-    transformRelativeToRootPath(path, rootPathSuffix) {
-      if (this.hasTildeInString(path)) {
+    transformRelativeToRootPath(path, filePath, rootPathSuffix = '') {
+      const fileBase = dirname(filePath);
+      if (this.startsWith(path, '~/')) {
         const withoutTilde = path.substring(2, path.length);
-        return `${this.root}${rootPathSuffix ? rootPathSuffix : ''}/${withoutTilde}`;
+        if (this.startsWith(rootPathSuffix, '%/')) {
+          const suffix = rootPathSuffix.substring(1, rootPathSuffix.length);
+          const localRoot = dirname(findPkg.sync(filePath));
+          return './' + relative(fileBase, `${localRoot}${suffix}/${withoutTilde}`);
+        }
+        const suffix = '/' + rootPathSuffix.replace(/^(\/)|(\/)$/g, '');
+        return './' + relative(fileBase, `${this.root}${suffix}/${withoutTilde}`);
       }
       if (typeof path === 'string') {
         return path;
@@ -14,17 +25,17 @@ export default function(path) {
       throw new Error('ERROR: No path passed');
     }
 
-    hasTildeInString(string) {
-      let containsTilde = false;
+    startsWith(string, target) {
+      let startsWithTarget = false;
 
       if (typeof string === 'string') {
-        const firstTwoCharactersOfString = string.substring(0, 2);
-        if (firstTwoCharactersOfString === '~/') {
-          containsTilde = true;
+        const firstCharactersOfString = string.substring(0, target.length);
+        if (firstCharactersOfString === target) {
+          startsWithTarget = true;
         }
       }
 
-      return containsTilde;
+      return startsWithTarget;
     }
   }
 

--- a/plugin/index.js
+++ b/plugin/index.js
@@ -9,12 +9,10 @@ export default function({ types: t }) {
           ImportDeclaration(path, state) {
             const givenPath = path.node.source.value;
 
-            var rootPathSuffix = state && state.opts && typeof state.opts.rootPathSuffix === 'string' ?
-            '/' + state.opts.rootPathSuffix.replace(/^(\/)|(\/)$/g, '') :
-                '';
+            var rootPathSuffix = state && state.opts && typeof state.opts.rootPathSuffix === 'string' ? state.opts.rootPathSuffix : '';
 
-            if(BabelRootImportHelper().hasTildeInString(givenPath)) {
-              path.node.source.value = BabelRootImportHelper().transformRelativeToRootPath(givenPath, rootPathSuffix);
+            if(BabelRootImportHelper().startsWith(givenPath, '~/')) {
+              path.node.source.value = BabelRootImportHelper().transformRelativeToRootPath(givenPath, state.file.opts.filename, rootPathSuffix);
             }
           }
         }

--- a/test/helper.spec.js
+++ b/test/helper.spec.js
@@ -1,4 +1,5 @@
 import BabelRootImportHelper from '../plugin/helper';
+import path from 'path';
 
 describe('Babel Root Import - Helper', () => {
 
@@ -10,9 +11,8 @@ describe('Babel Root Import - Helper', () => {
       });
 
       it('transforms given path relative root-path', () => {
-        const rootPath = `${process.cwd()}/some/path`;
         const result = BabelRootImportHelper().transformRelativeToRootPath('~/some/path');
-        expect(result).to.equal(rootPath);
+        expect(result).to.equal('./some/path');
       });
 
       it('throws error if no string is passed', () => {
@@ -31,14 +31,13 @@ describe('Babel Root Import - Helper', () => {
 
   describe('transformRelativeToRootPath', () => {
     it('returns a string', () => {
-      const func = BabelRootImportHelper().transformRelativeToRootPath('');
+      const func = BabelRootImportHelper().transformRelativeToRootPath('', __filename);
       expect(func).to.be.a('string');
     });
 
     it('transforms given path relative root-path', () => {
-      const rootPath = `${process.cwd()}/some/path`;
-      const result = BabelRootImportHelper().transformRelativeToRootPath('~/some/path');
-      expect(result).to.equal(rootPath);
+      const result = BabelRootImportHelper().transformRelativeToRootPath('~/some/path', __filename);
+      expect(result).to.equal('./../some/path');
     });
 
     it('throws error if no string is passed', () => {
@@ -48,22 +47,59 @@ describe('Babel Root Import - Helper', () => {
     });
   });
 
-  describe('hasTildeInString', () => {
+  describe('transformWithRootPathSuffix', () => {
+    it('returns a string', () => {
+      const func = BabelRootImportHelper().transformRelativeToRootPath('', __filename, 'src');
+      expect(func).to.be.a('string');
+    });
+
+    it('transforms given path relative root-path', () => {
+      const result = BabelRootImportHelper().transformRelativeToRootPath('~/some/path', __filename, 'src');
+      expect(result).to.equal('./../src/some/path');
+    });
+
+    it('throws error if no string is passed', () => {
+      expect(() => {
+        BabelRootImportHelper().transformRelativeToRootPath();
+      }).to.throw(Error);
+    });
+  });
+
+  describe('transformRelativeToClosestModule', () => {
+    it('returns a string', () => {
+      const func = BabelRootImportHelper().transformRelativeToRootPath('', __filename, '%/src');
+      expect(func).to.be.a('string');
+    });
+
+    it('transforms given path relative root-path', () => {
+      const otherModulePath = path.join(__dirname, '..', 'node_modules', 'mocha', 'index.js');
+      const result = BabelRootImportHelper().transformRelativeToRootPath('~/some/path', otherModulePath, '%/src');
+      expect(result).to.equal('./src/some/path');
+    });
+
+    it('throws error if no string is passed', () => {
+      expect(() => {
+        BabelRootImportHelper().transformRelativeToRootPath();
+      }).to.throw(Error);
+    });
+  });
+
+  describe('startsWith', () => {
     it('returns a boolean', () => {
-      const func = BabelRootImportHelper().hasTildeInString();
+      const func = BabelRootImportHelper().startsWith();
       expect(func).to.be.a('boolean');
     });
 
     it('check if a "~/" is at the beginning of the string', () => {
-      const withoutTilde = BabelRootImportHelper().hasTildeInString('some/path');
-      const withTilde = BabelRootImportHelper().hasTildeInString('~/some/path');
+      const withoutTilde = BabelRootImportHelper().startsWith('some/path', '~/');
+      const withTilde = BabelRootImportHelper().startsWith('~/some/path', '~/');
       expect(withoutTilde).to.be.false;
       expect(withTilde).to.be.true;
     });
 
     it('returns false if no string is passed', () => {
-      const nothingPassed = BabelRootImportHelper().hasTildeInString();
-      const wrongTypePassed = BabelRootImportHelper().hasTildeInString([]);
+      const nothingPassed = BabelRootImportHelper().startsWith();
+      const wrongTypePassed = BabelRootImportHelper().startsWith([]);
       expect(nothingPassed).to.be.false;
       expect(wrongTypePassed).to.be.false;
     });

--- a/test/plugin.spec.js
+++ b/test/plugin.spec.js
@@ -4,7 +4,7 @@ import * as babel from 'babel-core';
 describe('Babel Root Import - Plugin', () => {
   describe('Babel Plugin', () => {
     it('transforms the relative path into an absolute path', () => {
-      const targetRequire = `${process.cwd()}/some/example.js`;
+      const targetRequire = `./some/example.js`;
       const transformedCode = babel.transform("import SomeExample from '~/some/example.js';", {
         plugins: [BabelRootImportPlugin]
       });


### PR DESCRIPTION
Quite a lot of changes:

This packages uses absolute paths that don't play well with compiled files, it leads to compiles files requiring non-compiled files and breaks.

When you have several modules with one parent build system (like babel), you have to be able to dynamically adjust the rootPath. Plugged in `%/` syntax in the `rootPathSuffix` option to automatically bubble up to the closest `package.json` directory.

