### PR TITLE
Enable empty prefix imports without interfering with node_modues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules
 npm-debug.log
 build
+
+.idea

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-root-import",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "description": "Babel Plugin to enable relative root-import",
   "author": "Michael J. Zoidl <github@michaelzoidl.com>",
   "license": "MIT",
@@ -11,23 +11,26 @@
   ],
   "repository": "michaelzoidl/babel-root-import",
   "scripts": {
-    "test": "mocha test/*.spec.js --require config/mocha.js --compilers js:babel-core/register",
-    "test-watch": "mocha test/*.spec.js --require config/mocha.js --compilers js:babel-core/register --watch",
-    "lint-js": "eslint plugin",
-    "compile": "babel -d build/ plugin/"
+    "lint": "eslint index.js plugin/ test/",
+    "unit": "mocha test/*.spec.js --require config/mocha.js --compilers js:babel-core/register",
+    "unit-watch": "mocha test/*.spec.js --require config/mocha.js --compilers js:babel-core/register --watch",
+    "test": "npm run lint && npm run unit",
+    "compile": "babel -d build/ plugin/",
+    "prepublish": "npm run test && npm run compile"
   },
   "dependencies": {
-    "babel": "^6.1.18",
+    "resolve": "^1.1.7",
     "slash": "^1.0.0"
   },
   "devDependencies": {
-    "babel-core": "^6.2.1",
-    "babel-eslint": "^5.0.0",
-    "babel-preset-es2015": "^6.1.18",
-    "babel-preset-stage-1": "^6.1.18",
-    "chai": "^3.2.0",
-    "eslint": "^2.1.0",
-    "mocha": "^2.2.5",
-    "sinon": "^1.15.4"
+    "babel-cli": "^6.9.0",
+    "babel-core": "^6.9.1",
+    "babel-eslint": "^6.0.4",
+    "babel-preset-es2015": "^6.9.0",
+    "babel-preset-stage-1": "^6.5.0",
+    "chai": "^3.5.0",
+    "eslint": "^2.12.0",
+    "mocha": "^2.5.3",
+    "sinon": "^1.17.4"
   }
 }

--- a/plugin/index.js
+++ b/plugin/index.js
@@ -9,17 +9,15 @@ export default function() {
             const defaultPath = path.node.source.value;
 
             let rootPathSuffix = '';
-            let rootPathPrefix = '';
+            let rootPathPrefix = '~';
 
             if (state && state.opts) {
               if (state.opts.rootPathSuffix && typeof state.opts.rootPathSuffix === 'string') {
                 rootPathSuffix = `/${state.opts.rootPathSuffix.replace(/^(\/)|(\/)$/g, '')}`;
               }
 
-              if (state.opts.rootPathPrefix && typeof state.opts.rootPathPrefix === 'string') {
+              if (state.opts.rootPathPrefix !== undefined) {
                 rootPathPrefix = state.opts.rootPathPrefix;
-              } else {
-                rootPathPrefix = '~';
               }
             }
 

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,0 +1,6 @@
+{
+  "root": false,
+  "rules": {
+    "quote-props": 0
+  }
+}

--- a/test/helper.spec.js
+++ b/test/helper.spec.js
@@ -1,45 +1,39 @@
 import slash from 'slash';
-
 import BabelRootImportHelper from '../plugin/helper';
 
 describe('Babel Root Import - Helper', () => {
-
-  describe('transformRelativeToRootPath', () => {
-      it('returns a string', () => {
-        const func = BabelRootImportHelper().transformRelativeToRootPath('');
-        expect(func).to.be.a('string');
-      });
-
-      it('transforms given path relative root-path', () => {
-        const rootPath = slash(`${process.cwd()}/some/path`);
-        const result = BabelRootImportHelper().transformRelativeToRootPath('~/some/path');
-        expect(result).to.equal(rootPath);
-      });
-
-      it('throws error if no string is passed', () => {
-        expect(() => {
-          BabelRootImportHelper().transformRelativeToRootPath();
-        }).to.throw(Error);
-      });
-  });
-
-  describe('Class', () => {
-    it('returns the root path', () => {
-      const rootByProcess = slash(process.cwd());
-      expect(BabelRootImportHelper().root).to.equal(rootByProcess);
-    });
-  });
-
   describe('transformRelativeToRootPath', () => {
     it('returns a string', () => {
       const func = BabelRootImportHelper().transformRelativeToRootPath('');
+
       expect(func).to.be.a('string');
     });
 
-    it('transforms given path relative root-path', () => {
+    it('transforms given path relative root-path with ~ rootPathSuffix', () => {
       const rootPath = slash(`${process.cwd()}/some/path`);
       const result = BabelRootImportHelper().transformRelativeToRootPath('~/some/path');
+
       expect(result).to.equal(rootPath);
+    });
+
+    it('transforms path as relative root-path with "" rootPathSuffix', () => {
+      const rootPath = slash(`${process.cwd()}/some/path`);
+      const result = BabelRootImportHelper().transformRelativeToRootPath('some/path', null, '');
+
+      expect(result).to.equal(rootPath);
+    });
+
+    it('transforms path as relative root-path with / rootPathSuffix', () => {
+      const rootPath = slash(`${process.cwd()}/some/path`);
+      const result = BabelRootImportHelper().transformRelativeToRootPath('/some/path', null, '/');
+
+      expect(result).to.equal(rootPath);
+    });
+
+    it('returns original path if with "" rootPathSuffix and is in node_modules', () => {
+      const result = BabelRootImportHelper().transformRelativeToRootPath('slash', null, '');
+
+      expect(result).to.equal('slash');
     });
 
     it('throws error if no string is passed', () => {
@@ -49,22 +43,57 @@ describe('Babel Root Import - Helper', () => {
     });
   });
 
+  describe('Class', () => {
+    it('returns the root path', () => {
+      const rootByProcess = slash(process.cwd());
+
+      expect(BabelRootImportHelper().root).to.equal(rootByProcess);
+    });
+  });
+
   describe('hasRootPathPrefixInString', () => {
     it('returns a boolean', () => {
       const func = BabelRootImportHelper().hasRootPathPrefixInString();
+
       expect(func).to.be.a('boolean');
     });
 
     it('check if "~/" is at the beginning of the string', () => {
       const withoutRootPathPrefix = BabelRootImportHelper().hasRootPathPrefixInString('some/path');
       const withRootPathPrefix = BabelRootImportHelper().hasRootPathPrefixInString('~/some/path');
+
       expect(withoutRootPathPrefix).to.be.false;
       expect(withRootPathPrefix).to.be.true;
+    });
+
+    it('returns true if empty rootPathSuffix', () => {
+      const hasRootPathPrefix = BabelRootImportHelper().hasRootPathPrefixInString('some/path', null, '');
+
+      expect(hasRootPathPrefix).to.be.true;
+    });
+
+    it('returns false if empty rootPathSuffix and string starts with /', () => {
+      const hasRootPathPrefix = BabelRootImportHelper().hasRootPathPrefixInString('/some/path', null, '');
+
+      expect(hasRootPathPrefix).to.be.false;
+    });
+
+    it('returns false if empty rootPathSuffix and string starts with ./', () => {
+      const hasRootPathPrefix = BabelRootImportHelper().hasRootPathPrefixInString('./some/path', null, '');
+
+      expect(hasRootPathPrefix).to.be.false;
+    });
+
+    it('returns false if empty rootPathSuffix and string starts with .', () => {
+      const hasRootPathPrefix = BabelRootImportHelper().hasRootPathPrefixInString('../some/path', null, '');
+
+      expect(hasRootPathPrefix).to.be.false;
     });
 
     it('returns false if no string is passed', () => {
       const nothingPassed = BabelRootImportHelper().hasRootPathPrefixInString();
       const wrongTypePassed = BabelRootImportHelper().hasRootPathPrefixInString([]);
+
       expect(nothingPassed).to.be.false;
       expect(wrongTypePassed).to.be.false;
     });

--- a/test/plugin.spec.js
+++ b/test/plugin.spec.js
@@ -1,6 +1,5 @@
 import * as babel from 'babel-core';
 import slash from 'slash';
-
 import BabelRootImportPlugin from '../plugin';
 
 describe('Babel Root Import - Plugin', () => {
@@ -15,7 +14,7 @@ describe('Babel Root Import - Plugin', () => {
     });
 
     it('transforms the relative path into an absolute path with the configured root-path', () => {
-      const targetRequire = slash(`/some/custom/root/some/example.js`);
+      const targetRequire = slash('/some/custom/root/some/example.js');
       const transformedCode = babel.transform("import SomeExample from '~/some/example.js';", {
         plugins: [[
           BabelRootImportPlugin, {
@@ -59,6 +58,19 @@ describe('Babel Root Import - Plugin', () => {
         plugins: [[
           BabelRootImportPlugin, {
             rootPathPrefix: '-'
+          }
+        ]]
+      });
+
+      expect(transformedCode.code).to.contain(targetRequire);
+    });
+
+    it('uses empty string as custom prefix to detect a root-import path', () => {
+      const targetRequire = slash(`${process.cwd()}/some/example.js`);
+      const transformedCode = babel.transform("import SomeExample from 'some/example.js';", {
+        plugins: [[
+          BabelRootImportPlugin, {
+            rootPathPrefix: ''
           }
         ]]
       });


### PR DESCRIPTION
Can now do `import thing from 'some/path';` which is the same as doing `import thing from '~/some/path';`; will automatically check if `node_module` exist first. This allows `source_root` compatible IDE's such as WebStorm to properly resolve paths.