### PR TITLE
Added support for require calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Babel Root Import
-Babel plugin to add the opportunity to use `import` with root based paths.<br>
+Babel plugin to add the opportunity to use `import` and `require` with root based paths.<br>
 [![Build Status](https://travis-ci.org/michaelzoidl/babel-root-import.svg?branch=master)](https://travis-ci.org/michaelzoidl/babel-root-import)
 [![Codacy Badge](https://img.shields.io/codacy/98f77bcc84964e67a2754e563b962d27.svg)](https://www.codacy.com/app/me_1438/both-io)
 [![Dependency Status](https://david-dm.org/michaelzoidl/babel-root-import.svg)](https://david-dm.org/michaelzoidl/babel-root-import)
@@ -10,9 +10,11 @@ Babel plugin to add the opportunity to use `import` with root based paths.<br>
 ```javascript
 // Usually
 import SomeExample from '../../../some/example.js';
+const OtherExample = require('../../../other/example.js');
 
 // With Babel-Root-Importer
 import SomeExample from '~/some/example.js';
+const OtherExample = require('~/other/example.js');
 ```
 
 ## Install

--- a/plugin/helper.js
+++ b/plugin/helper.js
@@ -1,45 +1,38 @@
 import slash from 'slash';
 
-export default function() {
-  class BabelRootImportHelper {
+const root = slash(global.rootPath || process.cwd());
 
-    root = slash(global.rootPath || process.cwd())
+export const hasRootPathPrefixInString = (importPath, rootPathPrefix = '~') => {
+  let containsRootPathPrefix = false;
 
-    transformRelativeToRootPath(importPath, rootPathSuffix, rootPathPrefix) {
-      let withoutRootPathPrefix = '';
-      if (this.hasRootPathPrefixInString(importPath, rootPathPrefix)) {
-        if (importPath.substring(0, 1) === '/') {
-          withoutRootPathPrefix = importPath.substring(1, importPath.length);
-        } else {
-          withoutRootPathPrefix = importPath.substring(2, importPath.length);
-        }
-        return slash(`${this.root}${rootPathSuffix ? rootPathSuffix : ''}/${withoutRootPathPrefix}`);
-      }
-
-      if (typeof importPath === 'string') {
-        return importPath;
-      }
-
-      throw new Error('ERROR: No path passed');
+  if (typeof importPath === 'string') {
+    if (importPath.substring(0, 1) === rootPathPrefix) {
+      containsRootPathPrefix = true;
     }
 
-    hasRootPathPrefixInString(importPath, rootPathPrefix = '~') {
-      let containsRootPathPrefix = false;
-
-      if (typeof importPath === 'string') {
-        if (importPath.substring(0, 1) === rootPathPrefix) {
-          containsRootPathPrefix = true;
-        }
-
-        const firstTwoCharactersOfString = importPath.substring(0, 2);
-        if (firstTwoCharactersOfString === `${rootPathPrefix}/`) {
-          containsRootPathPrefix = true;
-        }
-      }
-
-      return containsRootPathPrefix;
+    const firstTwoCharactersOfString = importPath.substring(0, 2);
+    if (firstTwoCharactersOfString === `${rootPathPrefix}/`) {
+      containsRootPathPrefix = true;
     }
   }
 
-  return new BabelRootImportHelper();
-}
+  return containsRootPathPrefix;
+};
+
+export const transformRelativeToRootPath = (importPath, rootPathSuffix, rootPathPrefix) => {
+  let withoutRootPathPrefix = '';
+  if (hasRootPathPrefixInString(importPath, rootPathPrefix)) {
+    if (importPath.substring(0, 1) === '/') {
+      withoutRootPathPrefix = importPath.substring(1, importPath.length);
+    } else {
+      withoutRootPathPrefix = importPath.substring(2, importPath.length);
+    }
+    return slash(`${root}${rootPathSuffix ? rootPathSuffix : ''}/${withoutRootPathPrefix}`);
+  }
+
+  if (typeof importPath === 'string') {
+    return importPath;
+  }
+
+  throw new Error('ERROR: No path passed');
+};

--- a/plugin/index.js
+++ b/plugin/index.js
@@ -1,31 +1,51 @@
 import BabelRootImportHelper from './helper';
 
-export default function() {
+const replacePrefix = (path, opts = {}) => {
+  let rootPathSuffix = '';
+  let rootPathPrefix = '';
+
+  if (opts.rootPathSuffix && typeof opts.rootPathSuffix === 'string') {
+    rootPathSuffix = `/${opts.rootPathSuffix.replace(/^(\/)|(\/)$/g, '')}`;
+  }
+
+  if (opts.rootPathPrefix && typeof opts.rootPathPrefix === 'string') {
+    rootPathPrefix = opts.rootPathPrefix;
+  } else {
+    rootPathPrefix = '~';
+  }
+
+  if (BabelRootImportHelper().hasRootPathPrefixInString(path, rootPathPrefix)) {
+    return BabelRootImportHelper().transformRelativeToRootPath(path, rootPathSuffix, rootPathPrefix);
+  }
+
+  return path;
+};
+
+export default function({'types': t}) {
   class BabelRootImport {
     constructor() {
       return {
         'visitor': {
+          CallExpression(path, state) {
+            if (path.node.callee.name !== 'require') {
+              return;
+            }
+
+            const args = path.node.arguments;
+            if (!args.length) {
+              return;
+            }
+
+            const firstArg = args[0];
+            // If the require is `require('~/' + 'blah')` we can still change it
+            if (t.isBinaryExpression(firstArg) && t.isStringLiteral(firstArg.left)) {
+              firstArg.left.value = replacePrefix(firstArg.left.value, state.opts);
+            } else if (t.isLiteral(firstArg)) {
+              firstArg.value = replacePrefix(firstArg.value, state.opts);
+            }
+          },
           ImportDeclaration(path, state) {
-            const defaultPath = path.node.source.value;
-
-            let rootPathSuffix = '';
-            let rootPathPrefix = '';
-
-            if (state && state.opts) {
-              if (state.opts.rootPathSuffix && typeof state.opts.rootPathSuffix === 'string') {
-                rootPathSuffix = `/${state.opts.rootPathSuffix.replace(/^(\/)|(\/)$/g, '')}`;
-              }
-
-              if (state.opts.rootPathPrefix && typeof state.opts.rootPathPrefix === 'string') {
-                rootPathPrefix = state.opts.rootPathPrefix;
-              } else {
-                rootPathPrefix = '~';
-              }
-            }
-
-            if (BabelRootImportHelper().hasRootPathPrefixInString(defaultPath, rootPathPrefix)) {
-              path.node.source.value = BabelRootImportHelper().transformRelativeToRootPath(defaultPath, rootPathSuffix, rootPathPrefix);
-            }
+            path.node.source.value = replacePrefix(path.node.source.value, state.opts);
           }
         }
       };

--- a/plugin/index.js
+++ b/plugin/index.js
@@ -1,4 +1,4 @@
-import BabelRootImportHelper from './helper';
+import {hasRootPathPrefixInString, transformRelativeToRootPath} from './helper';
 
 const replacePrefix = (path, opts = {}) => {
   let rootPathSuffix = '';
@@ -14,43 +14,35 @@ const replacePrefix = (path, opts = {}) => {
     rootPathPrefix = '~';
   }
 
-  if (BabelRootImportHelper().hasRootPathPrefixInString(path, rootPathPrefix)) {
-    return BabelRootImportHelper().transformRelativeToRootPath(path, rootPathSuffix, rootPathPrefix);
+  if (hasRootPathPrefixInString(path, rootPathPrefix)) {
+    return transformRelativeToRootPath(path, rootPathSuffix, rootPathPrefix);
   }
 
   return path;
 };
 
-export default function({'types': t}) {
-  class BabelRootImport {
-    constructor() {
-      return {
-        'visitor': {
-          CallExpression(path, state) {
-            if (path.node.callee.name !== 'require') {
-              return;
-            }
+export default ({'types': t}) => ({
+  'visitor': {
+    CallExpression(path, state) {
+      if (path.node.callee.name !== 'require') {
+        return;
+      }
 
-            const args = path.node.arguments;
-            if (!args.length) {
-              return;
-            }
+      const args = path.node.arguments;
+      if (!args.length) {
+        return;
+      }
 
-            const firstArg = args[0];
-            // If the require is `require('~/' + 'blah')` we can still change it
-            if (t.isBinaryExpression(firstArg) && t.isStringLiteral(firstArg.left)) {
-              firstArg.left.value = replacePrefix(firstArg.left.value, state.opts);
-            } else if (t.isLiteral(firstArg)) {
-              firstArg.value = replacePrefix(firstArg.value, state.opts);
-            }
-          },
-          ImportDeclaration(path, state) {
-            path.node.source.value = replacePrefix(path.node.source.value, state.opts);
-          }
-        }
-      };
+      const firstArg = args[0];
+      // If the require is `require('~/' + 'blah')` we can still change it
+      if (t.isBinaryExpression(firstArg) && t.isStringLiteral(firstArg.left)) {
+        firstArg.left.value = replacePrefix(firstArg.left.value, state.opts);
+      } else if (t.isLiteral(firstArg)) {
+        firstArg.value = replacePrefix(firstArg.value, state.opts);
+      }
+    },
+    ImportDeclaration(path, state) {
+      path.node.source.value = replacePrefix(path.node.source.value, state.opts);
     }
   }
-
-  return new BabelRootImport();
-}
+});

--- a/test/helper.spec.js
+++ b/test/helper.spec.js
@@ -1,72 +1,42 @@
+import {hasRootPathPrefixInString, transformRelativeToRootPath} from '../plugin/helper';
 import slash from 'slash';
 
-import BabelRootImportHelper from '../plugin/helper';
-
-describe('Babel Root Import - Helper', () => {
-
-  describe('transformRelativeToRootPath', () => {
-      it('returns a string', () => {
-        const func = BabelRootImportHelper().transformRelativeToRootPath('');
-        expect(func).to.be.a('string');
-      });
-
-      it('transforms given path relative root-path', () => {
-        const rootPath = slash(`${process.cwd()}/some/path`);
-        const result = BabelRootImportHelper().transformRelativeToRootPath('~/some/path');
-        expect(result).to.equal(rootPath);
-      });
-
-      it('throws error if no string is passed', () => {
-        expect(() => {
-          BabelRootImportHelper().transformRelativeToRootPath();
-        }).to.throw(Error);
-      });
+describe('helper#transformRelativeToRootPath', () => {
+  it('returns a string', () => {
+    const func = transformRelativeToRootPath('');
+    expect(func).to.be.a('string');
   });
 
-  describe('Class', () => {
-    it('returns the root path', () => {
-      const rootByProcess = slash(process.cwd());
-      expect(BabelRootImportHelper().root).to.equal(rootByProcess);
-    });
+  it('transforms given path relative root-path', () => {
+    const rootPath = slash(`${process.cwd()}/some/path`);
+    const result = transformRelativeToRootPath('~/some/path');
+    expect(result).to.equal(rootPath);
   });
 
-  describe('transformRelativeToRootPath', () => {
-    it('returns a string', () => {
-      const func = BabelRootImportHelper().transformRelativeToRootPath('');
-      expect(func).to.be.a('string');
-    });
+  it('throws error if no string is passed', () => {
+    expect(() => {
+      transformRelativeToRootPath();
+    }).to.throw(Error);
+  });
+});
 
-    it('transforms given path relative root-path', () => {
-      const rootPath = slash(`${process.cwd()}/some/path`);
-      const result = BabelRootImportHelper().transformRelativeToRootPath('~/some/path');
-      expect(result).to.equal(rootPath);
-    });
-
-    it('throws error if no string is passed', () => {
-      expect(() => {
-        BabelRootImportHelper().transformRelativeToRootPath();
-      }).to.throw(Error);
-    });
+describe('helper#hasRootPathPrefixInString', () => {
+  it('returns a boolean', () => {
+    const func = hasRootPathPrefixInString();
+    expect(func).to.be.a('boolean');
   });
 
-  describe('hasRootPathPrefixInString', () => {
-    it('returns a boolean', () => {
-      const func = BabelRootImportHelper().hasRootPathPrefixInString();
-      expect(func).to.be.a('boolean');
-    });
+  it('check if "~/" is at the beginning of the string', () => {
+    const withoutRootPathPrefix = hasRootPathPrefixInString('some/path');
+    const withRootPathPrefix = hasRootPathPrefixInString('~/some/path');
+    expect(withoutRootPathPrefix).to.be.false;
+    expect(withRootPathPrefix).to.be.true;
+  });
 
-    it('check if "~/" is at the beginning of the string', () => {
-      const withoutRootPathPrefix = BabelRootImportHelper().hasRootPathPrefixInString('some/path');
-      const withRootPathPrefix = BabelRootImportHelper().hasRootPathPrefixInString('~/some/path');
-      expect(withoutRootPathPrefix).to.be.false;
-      expect(withRootPathPrefix).to.be.true;
-    });
-
-    it('returns false if no string is passed', () => {
-      const nothingPassed = BabelRootImportHelper().hasRootPathPrefixInString();
-      const wrongTypePassed = BabelRootImportHelper().hasRootPathPrefixInString([]);
-      expect(nothingPassed).to.be.false;
-      expect(wrongTypePassed).to.be.false;
-    });
+  it('returns false if no string is passed', () => {
+    const nothingPassed = hasRootPathPrefixInString();
+    const wrongTypePassed = hasRootPathPrefixInString([]);
+    expect(nothingPassed).to.be.false;
+    expect(wrongTypePassed).to.be.false;
   });
 });

--- a/test/plugin.spec.js
+++ b/test/plugin.spec.js
@@ -18,7 +18,7 @@ describe('Babel Root Import - Plugin', () => {
   });
 
   it('transforms the relative path into an absolute path with the configured root-path', () => {
-    const targetRequire = slash(`/some/custom/root/some/example.js`);
+    const targetRequire = slash('/some/custom/root/some/example.js');
     const transformedImport = babel.transform("import SomeExample from '~/some/example.js';", {
       plugins: [[
         BabelRootImportPlugin, {
@@ -125,12 +125,19 @@ describe('Babel Root Import - Plugin', () => {
   });
 
   it('transforms a multipart require path with string at the beginning', () => {
-    const targetRequire = slash(`${process.cwd()}/some/' + 'example.js`);
-    const transformedRequire = babel.transform("var SomeExample = require('~/some/' + 'example.js');", {
+    const targetRequire1 = slash(`${process.cwd()}/some/' + 'example.js`);
+    const transformedRequire1 = babel.transform("var SomeExample = require('~/some/' + 'example.js');", {
       plugins: [BabelRootImportPlugin]
     });
 
-    expect(transformedRequire.code).to.contain(targetRequire);
+    expect(transformedRequire1.code).to.contain(targetRequire1);
+
+    const targetRequire2 = slash(`${process.cwd()}/some/' + 'other' + 'example.js`);
+    const transformedRequire2 = babel.transform("var SomeExample = require('~/some/' + 'other' + 'example.js');", {
+      plugins: [BabelRootImportPlugin]
+    });
+
+    expect(transformedRequire2.code).to.contain(targetRequire2);
   });
 
   it('does not transform a multipart require path with variable at the beginning', () => {

--- a/test/plugin.spec.js
+++ b/test/plugin.spec.js
@@ -4,143 +4,141 @@ import slash from 'slash';
 import BabelRootImportPlugin from '../plugin';
 
 describe('Babel Root Import - Plugin', () => {
-  describe('Babel Plugin', () => {
-    it('transforms the relative path into an absolute path', () => {
-      const targetRequire = slash(`${process.cwd()}/some/example.js`);
-      const transformedImport = babel.transform("import SomeExample from '~/some/example.js';", {
-        plugins: [BabelRootImportPlugin]
-      });
-      const transformedRequire = babel.transform("var SomeExample = require('~/some/example.js');", {
-        plugins: [BabelRootImportPlugin]
-      });
-
-      expect(transformedImport.code).to.contain(targetRequire);
-      expect(transformedRequire.code).to.contain(targetRequire);
+  it('transforms the relative path into an absolute path', () => {
+    const targetRequire = slash(`${process.cwd()}/some/example.js`);
+    const transformedImport = babel.transform("import SomeExample from '~/some/example.js';", {
+      plugins: [BabelRootImportPlugin]
+    });
+    const transformedRequire = babel.transform("var SomeExample = require('~/some/example.js');", {
+      plugins: [BabelRootImportPlugin]
     });
 
-    it('transforms the relative path into an absolute path with the configured root-path', () => {
-      const targetRequire = slash(`/some/custom/root/some/example.js`);
-      const transformedImport = babel.transform("import SomeExample from '~/some/example.js';", {
-        plugins: [[
-          BabelRootImportPlugin, {
-            rootPathSuffix: 'some/custom/root'
-          }
-        ]]
-      });
-      const transformedRequire = babel.transform("var SomeExample = require('~/some/example.js');", {
-        plugins: [[
-          BabelRootImportPlugin, {
-            rootPathSuffix: 'some/custom/root'
-          }
-        ]]
-      });
+    expect(transformedImport.code).to.contain(targetRequire);
+    expect(transformedRequire.code).to.contain(targetRequire);
+  });
 
-      expect(transformedImport.code).to.contain(targetRequire);
-      expect(transformedRequire.code).to.contain(targetRequire);
+  it('transforms the relative path into an absolute path with the configured root-path', () => {
+    const targetRequire = slash(`/some/custom/root/some/example.js`);
+    const transformedImport = babel.transform("import SomeExample from '~/some/example.js';", {
+      plugins: [[
+        BabelRootImportPlugin, {
+          rootPathSuffix: 'some/custom/root'
+        }
+      ]]
+    });
+    const transformedRequire = babel.transform("var SomeExample = require('~/some/example.js');", {
+      plugins: [[
+        BabelRootImportPlugin, {
+          rootPathSuffix: 'some/custom/root'
+        }
+      ]]
     });
 
-    it('uses the "@" as custom prefix to detect a root-import path', () => {
-      const targetRequire = slash(`${process.cwd()}/some/example.js`);
-      const transformedImport = babel.transform("import SomeExample from '@/some/example.js';", {
-        plugins: [[
-          BabelRootImportPlugin, {
-            rootPathPrefix: '@'
-          }
-        ]]
-      });
-      const transformedRequire = babel.transform("var SomeExample = require('@/some/example.js');", {
-        plugins: [[
-          BabelRootImportPlugin, {
-            rootPathPrefix: '@'
-          }
-        ]]
-      });
+    expect(transformedImport.code).to.contain(targetRequire);
+    expect(transformedRequire.code).to.contain(targetRequire);
+  });
 
-      expect(transformedImport.code).to.contain(targetRequire);
-      expect(transformedRequire.code).to.contain(targetRequire);
+  it('uses the "@" as custom prefix to detect a root-import path', () => {
+    const targetRequire = slash(`${process.cwd()}/some/example.js`);
+    const transformedImport = babel.transform("import SomeExample from '@/some/example.js';", {
+      plugins: [[
+        BabelRootImportPlugin, {
+          rootPathPrefix: '@'
+        }
+      ]]
+    });
+    const transformedRequire = babel.transform("var SomeExample = require('@/some/example.js');", {
+      plugins: [[
+        BabelRootImportPlugin, {
+          rootPathPrefix: '@'
+        }
+      ]]
     });
 
-    it('uses the "/" as custom prefix to detect a root-import path', () => {
-      const targetRequire = slash(`${process.cwd()}/some/example.js`);
-      const transformedImport = babel.transform("import SomeExample from '/some/example.js';", {
-        plugins: [[
-          BabelRootImportPlugin, {
-            rootPathPrefix: '/'
-          }
-        ]]
-      });
-      const transformedRequire = babel.transform("var SomeExample = require('/some/example.js');", {
-        plugins: [[
-          BabelRootImportPlugin, {
-            rootPathPrefix: '/'
-          }
-        ]]
-      });
+    expect(transformedImport.code).to.contain(targetRequire);
+    expect(transformedRequire.code).to.contain(targetRequire);
+  });
 
-      expect(transformedImport.code).to.contain(targetRequire);
-      expect(transformedRequire.code).to.contain(targetRequire);
+  it('uses the "/" as custom prefix to detect a root-import path', () => {
+    const targetRequire = slash(`${process.cwd()}/some/example.js`);
+    const transformedImport = babel.transform("import SomeExample from '/some/example.js';", {
+      plugins: [[
+        BabelRootImportPlugin, {
+          rootPathPrefix: '/'
+        }
+      ]]
+    });
+    const transformedRequire = babel.transform("var SomeExample = require('/some/example.js');", {
+      plugins: [[
+        BabelRootImportPlugin, {
+          rootPathPrefix: '/'
+        }
+      ]]
     });
 
-    it('uses the "–" as custom prefix to detect a root-import path', () => {
-      const targetRequire = slash(`${process.cwd()}/some/example.js`);
-      const transformedImport = babel.transform("import SomeExample from '-/some/example.js';", {
-        plugins: [[
-          BabelRootImportPlugin, {
-            rootPathPrefix: '-'
-          }
-        ]]
-      });
-      const transformedRequire = babel.transform("var SomeExample = require('-/some/example.js');", {
-        plugins: [[
-          BabelRootImportPlugin, {
-            rootPathPrefix: '-'
-          }
-        ]]
-      });
+    expect(transformedImport.code).to.contain(targetRequire);
+    expect(transformedRequire.code).to.contain(targetRequire);
+  });
 
-      expect(transformedImport.code).to.contain(targetRequire);
-      expect(transformedRequire.code).to.contain(targetRequire);
+  it('uses the "–" as custom prefix to detect a root-import path', () => {
+    const targetRequire = slash(`${process.cwd()}/some/example.js`);
+    const transformedImport = babel.transform("import SomeExample from '-/some/example.js';", {
+      plugins: [[
+        BabelRootImportPlugin, {
+          rootPathPrefix: '-'
+        }
+      ]]
+    });
+    const transformedRequire = babel.transform("var SomeExample = require('-/some/example.js');", {
+      plugins: [[
+        BabelRootImportPlugin, {
+          rootPathPrefix: '-'
+        }
+      ]]
     });
 
-    it('uses "@" as custom prefix to detect a root-import path and has a custom rootPathSuffix', () => {
-      const targetRequire = slash(`${process.cwd()}/some/example.js`);
-      const transformedImport = babel.transform("import SomeExample from '@/example.js';", {
-        plugins: [[
-          BabelRootImportPlugin, {
-            rootPathPrefix: '@',
-            rootPathSuffix: 'some'
-          }
-        ]]
-      });
-      const transformedRequire = babel.transform("var SomeExample = require('@/example.js');", {
-        plugins: [[
-          BabelRootImportPlugin, {
-            rootPathPrefix: '@',
-            rootPathSuffix: 'some'
-          }
-        ]]
-      });
+    expect(transformedImport.code).to.contain(targetRequire);
+    expect(transformedRequire.code).to.contain(targetRequire);
+  });
 
-      expect(transformedImport.code).to.contain(targetRequire);
-      expect(transformedRequire.code).to.contain(targetRequire);
+  it('uses "@" as custom prefix to detect a root-import path and has a custom rootPathSuffix', () => {
+    const targetRequire = slash(`${process.cwd()}/some/example.js`);
+    const transformedImport = babel.transform("import SomeExample from '@/example.js';", {
+      plugins: [[
+        BabelRootImportPlugin, {
+          rootPathPrefix: '@',
+          rootPathSuffix: 'some'
+        }
+      ]]
+    });
+    const transformedRequire = babel.transform("var SomeExample = require('@/example.js');", {
+      plugins: [[
+        BabelRootImportPlugin, {
+          rootPathPrefix: '@',
+          rootPathSuffix: 'some'
+        }
+      ]]
     });
 
-    it('transforms a multipart require path with string at the beginning', () => {
-      const targetRequire = slash(`${process.cwd()}/some/' + 'example.js`);
-      const transformedRequire = babel.transform("var SomeExample = require('~/some/' + 'example.js');", {
-        plugins: [BabelRootImportPlugin]
-      });
+    expect(transformedImport.code).to.contain(targetRequire);
+    expect(transformedRequire.code).to.contain(targetRequire);
+  });
 
-      expect(transformedRequire.code).to.contain(targetRequire);
+  it('transforms a multipart require path with string at the beginning', () => {
+    const targetRequire = slash(`${process.cwd()}/some/' + 'example.js`);
+    const transformedRequire = babel.transform("var SomeExample = require('~/some/' + 'example.js');", {
+      plugins: [BabelRootImportPlugin]
     });
 
-    it('does not transform a multipart require path with variable at the beginning', () => {
-      const targetRequire = slash(`${process.cwd()}/some' + '/example.js`);
-      const transformedRequire = babel.transform("var some = '~/';var SomeExample = require(some+ '/example.js');", {
-        plugins: [BabelRootImportPlugin]
-      });
+    expect(transformedRequire.code).to.contain(targetRequire);
+  });
 
-      expect(transformedRequire.code).to.not.contain(targetRequire);
+  it('does not transform a multipart require path with variable at the beginning', () => {
+    const targetRequire = slash(`${process.cwd()}/some' + '/example.js`);
+    const transformedRequire = babel.transform("var some = '~/';var SomeExample = require(some+ '/example.js');", {
+      plugins: [BabelRootImportPlugin]
     });
+
+    expect(transformedRequire.code).to.not.contain(targetRequire);
   });
 });

--- a/test/plugin.spec.js
+++ b/test/plugin.spec.js
@@ -7,16 +7,27 @@ describe('Babel Root Import - Plugin', () => {
   describe('Babel Plugin', () => {
     it('transforms the relative path into an absolute path', () => {
       const targetRequire = slash(`${process.cwd()}/some/example.js`);
-      const transformedCode = babel.transform("import SomeExample from '~/some/example.js';", {
+      const transformedImport = babel.transform("import SomeExample from '~/some/example.js';", {
+        plugins: [BabelRootImportPlugin]
+      });
+      const transformedRequire = babel.transform("var SomeExample = require('~/some/example.js');", {
         plugins: [BabelRootImportPlugin]
       });
 
-      expect(transformedCode.code).to.contain(targetRequire);
+      expect(transformedImport.code).to.contain(targetRequire);
+      expect(transformedRequire.code).to.contain(targetRequire);
     });
 
     it('transforms the relative path into an absolute path with the configured root-path', () => {
       const targetRequire = slash(`/some/custom/root/some/example.js`);
-      const transformedCode = babel.transform("import SomeExample from '~/some/example.js';", {
+      const transformedImport = babel.transform("import SomeExample from '~/some/example.js';", {
+        plugins: [[
+          BabelRootImportPlugin, {
+            rootPathSuffix: 'some/custom/root'
+          }
+        ]]
+      });
+      const transformedRequire = babel.transform("var SomeExample = require('~/some/example.js');", {
         plugins: [[
           BabelRootImportPlugin, {
             rootPathSuffix: 'some/custom/root'
@@ -24,12 +35,20 @@ describe('Babel Root Import - Plugin', () => {
         ]]
       });
 
-      expect(transformedCode.code).to.contain(targetRequire);
+      expect(transformedImport.code).to.contain(targetRequire);
+      expect(transformedRequire.code).to.contain(targetRequire);
     });
 
     it('uses the "@" as custom prefix to detect a root-import path', () => {
       const targetRequire = slash(`${process.cwd()}/some/example.js`);
-      const transformedCode = babel.transform("import SomeExample from '@/some/example.js';", {
+      const transformedImport = babel.transform("import SomeExample from '@/some/example.js';", {
+        plugins: [[
+          BabelRootImportPlugin, {
+            rootPathPrefix: '@'
+          }
+        ]]
+      });
+      const transformedRequire = babel.transform("var SomeExample = require('@/some/example.js');", {
         plugins: [[
           BabelRootImportPlugin, {
             rootPathPrefix: '@'
@@ -37,12 +56,20 @@ describe('Babel Root Import - Plugin', () => {
         ]]
       });
 
-      expect(transformedCode.code).to.contain(targetRequire);
+      expect(transformedImport.code).to.contain(targetRequire);
+      expect(transformedRequire.code).to.contain(targetRequire);
     });
 
     it('uses the "/" as custom prefix to detect a root-import path', () => {
       const targetRequire = slash(`${process.cwd()}/some/example.js`);
-      const transformedCode = babel.transform("import SomeExample from '/some/example.js';", {
+      const transformedImport = babel.transform("import SomeExample from '/some/example.js';", {
+        plugins: [[
+          BabelRootImportPlugin, {
+            rootPathPrefix: '/'
+          }
+        ]]
+      });
+      const transformedRequire = babel.transform("var SomeExample = require('/some/example.js');", {
         plugins: [[
           BabelRootImportPlugin, {
             rootPathPrefix: '/'
@@ -50,12 +77,20 @@ describe('Babel Root Import - Plugin', () => {
         ]]
       });
 
-      expect(transformedCode.code).to.contain(targetRequire);
+      expect(transformedImport.code).to.contain(targetRequire);
+      expect(transformedRequire.code).to.contain(targetRequire);
     });
 
     it('uses the "–" as custom prefix to detect a root-import path', () => {
       const targetRequire = slash(`${process.cwd()}/some/example.js`);
-      const transformedCode = babel.transform("import SomeExample from '-/some/example.js';", {
+      const transformedImport = babel.transform("import SomeExample from '-/some/example.js';", {
+        plugins: [[
+          BabelRootImportPlugin, {
+            rootPathPrefix: '-'
+          }
+        ]]
+      });
+      const transformedRequire = babel.transform("var SomeExample = require('-/some/example.js');", {
         plugins: [[
           BabelRootImportPlugin, {
             rootPathPrefix: '-'
@@ -63,12 +98,21 @@ describe('Babel Root Import - Plugin', () => {
         ]]
       });
 
-      expect(transformedCode.code).to.contain(targetRequire);
+      expect(transformedImport.code).to.contain(targetRequire);
+      expect(transformedRequire.code).to.contain(targetRequire);
     });
 
     it('uses "@" as custom prefix to detect a root-import path and has a custom rootPathSuffix', () => {
       const targetRequire = slash(`${process.cwd()}/some/example.js`);
-      const transformedCode = babel.transform("import SomeExample from '@/example.js';", {
+      const transformedImport = babel.transform("import SomeExample from '@/example.js';", {
+        plugins: [[
+          BabelRootImportPlugin, {
+            rootPathPrefix: '@',
+            rootPathSuffix: 'some'
+          }
+        ]]
+      });
+      const transformedRequire = babel.transform("var SomeExample = require('@/example.js');", {
         plugins: [[
           BabelRootImportPlugin, {
             rootPathPrefix: '@',
@@ -77,7 +121,26 @@ describe('Babel Root Import - Plugin', () => {
         ]]
       });
 
-      expect(transformedCode.code).to.contain(targetRequire);
+      expect(transformedImport.code).to.contain(targetRequire);
+      expect(transformedRequire.code).to.contain(targetRequire);
+    });
+
+    it('transforms a multipart require path with string at the beginning', () => {
+      const targetRequire = slash(`${process.cwd()}/some/' + 'example.js`);
+      const transformedRequire = babel.transform("var SomeExample = require('~/some/' + 'example.js');", {
+        plugins: [BabelRootImportPlugin]
+      });
+
+      expect(transformedRequire.code).to.contain(targetRequire);
+    });
+
+    it('does not transform a multipart require path with variable at the beginning', () => {
+      const targetRequire = slash(`${process.cwd()}/some' + '/example.js`);
+      const transformedRequire = babel.transform("var some = '~/';var SomeExample = require(some+ '/example.js');", {
+        plugins: [BabelRootImportPlugin]
+      });
+
+      expect(transformedRequire.code).to.not.contain(targetRequire);
     });
   });
 });


### PR DESCRIPTION
Implements #19.

- [x] Abstract options check and call to `./helper` functions into `replacePrefix` function
- [x] Add support for `require` calls. The following are supported:
  - [x] `require('~/blah/example')`
  - [x] `require('~/' + someVariable + '/example')`
- [x] Remove classes in `plugin.js` and `helper.js` and replace with simple functions
- [x] Update tests

I put the conversion of the classes into functions so you can remove it if you want. It does the same thing but it's less code.

Require calls can be dynamic (unlike import statements) so I tried to support anything as long as it starts with a string. A call like `require(someVariable + '/example')` won't be considered. I've added some tests for this.