### PR TITLE
Removes `babel` as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "compile": "babel -d build/ plugin/"
   },
   "dependencies": {
-    "babel": "^6.1.18",
     "slash": "^1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Just something else I noticed 😄 

`babel` isn't needed as a dependency as the plugin just returns a function.