### PR TITLE
Clarified ESLint instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,11 +86,11 @@ const bar = require('@/my-file');
 ```
 
 ### Don't let ESLint be confused
-Add this to your .eslintrc so that ESLint won't treat the import as error
+If you use [eslint-plugin-import](https://github.com/benmosher/eslint-plugin-import) to validate imports it may be necessary to instruct ESLint to ignore root imports. Add the following to your .eslintrc file, replacing `~` with your chosen prefix.
 ```
 {
   "rules": {
-      "import/no-unresolved": [2, { ignore: ['\~*'] }]
+      "import/no-unresolved": [2, { "ignore": ["^[~]"] }]
   },
 }
 ```


### PR DESCRIPTION
It seems that ESLint does not lint imports by default; this functionality is provided by a plugin. Without the plugin, ESLint will throw an error due to the unknown `import/no-unresolved` rule.

Once eslint-plugin-import is installed, the provided pattern `\~*` was causing *all* imports to be ignored because any string will match that RegExp. The new pattern is `^[~]` matching any import starting with a tilde. The brackets should make it a little safer for anyone choosing a custom prefix to just swap the ~ character (e.g. `^[*]` which will match anything beginning with an asterisk vs `^*` which is not a valid regular expression).

There is an ESLint plugin [eslint-import-resolver-babel-root-import](https://github.com/olalonde/eslint-import-resolver-babel-root-import) meant to ensure that babel-root-import statements are actually verified rather than ignored. However, [as discussed in that project](https://github.com/olalonde/eslint-import-resolver-babel-root-import/issues/1), the current state of babel plugins requires each plugin to validate every possible type of import rather than allowing plugins to chain together. Since this plugin will only work in limited circumstances I did not include  a link in the README.