### PR TITLE
use relative paths instead of absolute ones, fixes #14

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "babel-preset-es2015": "^6.1.18",
     "babel-preset-stage-1": "^6.1.18",
     "chai": "^3.2.0",
-    "eslint": "^2.1.0",
+    "eslint": "~2.1.0",
     "mocha": "^2.2.5",
     "sinon": "^1.15.4"
   }

--- a/plugin/helper.js
+++ b/plugin/helper.js
@@ -1,4 +1,5 @@
 import slash from 'slash';
+import path from 'path';
 
 const root = slash(global.rootPath || process.cwd());
 
@@ -19,7 +20,7 @@ export const hasRootPathPrefixInString = (importPath, rootPathPrefix = '~') => {
   return containsRootPathPrefix;
 };
 
-export const transformRelativeToRootPath = (importPath, rootPathSuffix, rootPathPrefix) => {
+export const transformRelativeToRootPath = (importPath, rootPathSuffix, rootPathPrefix, sourceFile = '') => {
   let withoutRootPathPrefix = '';
   if (hasRootPathPrefixInString(importPath, rootPathPrefix)) {
     if (importPath.substring(0, 1) === '/') {
@@ -27,7 +28,28 @@ export const transformRelativeToRootPath = (importPath, rootPathSuffix, rootPath
     } else {
       withoutRootPathPrefix = importPath.substring(2, importPath.length);
     }
-    return slash(`${root}${rootPathSuffix ? rootPathSuffix : ''}/${withoutRootPathPrefix}`);
+
+    const absolutePath = `${rootPathSuffix ? rootPathSuffix : ''}/${withoutRootPathPrefix}`;
+    let sourcePath = sourceFile.substring(0, sourceFile.lastIndexOf('/'));
+
+    // if the path is an absolute path (webpack sends '/Users/foo/bar/baz.js' here)
+    if (sourcePath.indexOf('/') === 0) {
+      sourcePath = sourcePath.substring(root.length + 1);
+    }
+
+    let relativePath = slash(path.relative(`/${sourcePath}`, absolutePath));
+
+    // if file is located in the same folder
+    if (relativePath.indexOf('../') !== 0) {
+      relativePath = './' + relativePath;
+    }
+
+    // if the entry has a slash, keep it
+    if (importPath[importPath.length - 1] === '/') {
+      relativePath += '/';
+    }
+
+    return relativePath;
   }
 
   if (typeof importPath === 'string') {

--- a/plugin/index.js
+++ b/plugin/index.js
@@ -1,6 +1,6 @@
 import {hasRootPathPrefixInString, transformRelativeToRootPath} from './helper';
 
-const replacePrefix = (path, opts = []) => {
+const replacePrefix = (path, opts = [], sourceFile) => {
   const options = [].concat(opts);
 
   for (let i = 0; i < options.length; i++) {
@@ -19,7 +19,7 @@ const replacePrefix = (path, opts = []) => {
     }
 
     if (hasRootPathPrefixInString(path, rootPathPrefix)) {
-      return transformRelativeToRootPath(path, rootPathSuffix, rootPathPrefix);
+      return transformRelativeToRootPath(path, rootPathSuffix, rootPathPrefix, sourceFile);
     }
   }
 
@@ -59,20 +59,20 @@ export default ({'types': t}) => ({
       const firstArg = traverseExpression(t, args[0]);
 
       if (firstArg) {
-        firstArg.value = replacePrefix(firstArg.value, state.opts);
+        firstArg.value = replacePrefix(firstArg.value, state.opts, state.file.opts.filename);
       }
     },
     ImportDeclaration(path, state) {
-      path.node.source.value = replacePrefix(path.node.source.value, state.opts);
+      path.node.source.value = replacePrefix(path.node.source.value, state.opts, state.file.opts.filename);
     },
     ExportNamedDeclaration(path, state) {
       if (path.node.source) {
-        path.node.source.value = replacePrefix(path.node.source.value, state.opts);
+        path.node.source.value = replacePrefix(path.node.source.value, state.opts, state.file.opts.filename);
       }
     },
     ExportAllDeclaration(path, state) {
       if (path.node.source) {
-        path.node.source.value = replacePrefix(path.node.source.value, state.opts);
+        path.node.source.value = replacePrefix(path.node.source.value, state.opts, state.file.opts.filename);
       }
     }
   }

--- a/test/helper.spec.js
+++ b/test/helper.spec.js
@@ -7,9 +7,9 @@ describe('helper#transformRelativeToRootPath', () => {
     expect(func).to.be.a('string');
   });
 
-  it('transforms given path relative root-path', () => {
-    const rootPath = slash(`${process.cwd()}/some/path`);
-    const result = transformRelativeToRootPath('~/some/path');
+  it('transforms given path relative path', () => {
+    const rootPath = slash(`./path`);
+    const result = transformRelativeToRootPath('~/some/path', '', '~', 'some/file.js');
     expect(result).to.equal(rootPath);
   });
 

--- a/test/plugin.spec.js
+++ b/test/plugin.spec.js
@@ -5,7 +5,7 @@ import BabelRootImportPlugin from '../plugin';
 
 describe('Babel Root Import - Plugin', () => {
   it('transforms the relative path into an absolute path', () => {
-    const targetRequire = slash(`${process.cwd()}/some/example.js`);
+    const targetRequire = slash(`/some/example.js`);
     const transformedImport = babel.transform("import SomeExample from '~/some/example.js';", {
       plugins: [BabelRootImportPlugin]
     });
@@ -72,7 +72,7 @@ describe('Babel Root Import - Plugin', () => {
   });
 
   it('uses the "@" as custom prefix to detect a root-import path', () => {
-    const targetRequire = slash(`${process.cwd()}/some/example.js`);
+    const targetRequire = slash(`/some/example.js`);
     const transformedImport = babel.transform("import SomeExample from '@/some/example.js';", {
       plugins: [[
         BabelRootImportPlugin, {
@@ -93,15 +93,15 @@ describe('Babel Root Import - Plugin', () => {
   });
 
   it('supports re-export syntax (export * from ... or export { named } from ...)', () => {
-    const targetRequire = slash(`${process.cwd()}/some/example.js`);
-    const transformedExportNamed = babel.transform("export * from '@/some/example.js';", {
+    const targetRequire = slash(`/some/example.js`);
+    const transformedExportAll = babel.transform("export * from '@/some/example.js';", {
       plugins: [[
         BabelRootImportPlugin, {
           rootPathPrefix: '@'
         }
       ]]
     });
-    const transformedExportAll = babel.transform("export { named } from '@/some/example.js';", {
+    const transformedExportNamed = babel.transform("export { named } from '@/some/example.js';", {
       plugins: [[
         BabelRootImportPlugin, {
           rootPathPrefix: '@'
@@ -113,7 +113,7 @@ describe('Babel Root Import - Plugin', () => {
   });
 
   it('uses the "/" as custom prefix to detect a root-import path', () => {
-    const targetRequire = slash(`${process.cwd()}/some/example.js`);
+    const targetRequire = slash(`/some/example.js`);
     const transformedImport = babel.transform("import SomeExample from '/some/example.js';", {
       plugins: [[
         BabelRootImportPlugin, {
@@ -134,7 +134,7 @@ describe('Babel Root Import - Plugin', () => {
   });
 
   it('uses the "–" as custom prefix to detect a root-import path', () => {
-    const targetRequire = slash(`${process.cwd()}/some/example.js`);
+    const targetRequire = slash(`/some/example.js`);
     const transformedImport = babel.transform("import SomeExample from '-/some/example.js';", {
       plugins: [[
         BabelRootImportPlugin, {
@@ -155,7 +155,7 @@ describe('Babel Root Import - Plugin', () => {
   });
 
   it('uses "@" as custom prefix to detect a root-import path and has a custom rootPathSuffix', () => {
-    const targetRequire = slash(`${process.cwd()}/some/example.js`);
+    const targetRequire = slash(`/some/example.js`);
     const transformedImport = babel.transform("import SomeExample from '@/example.js';", {
       plugins: [[
         BabelRootImportPlugin, {
@@ -178,14 +178,14 @@ describe('Babel Root Import - Plugin', () => {
   });
 
   it('transforms a multipart require path with string at the beginning', () => {
-    const targetRequire1 = slash(`${process.cwd()}/some/' + 'example.js`);
+    const targetRequire1 = slash(`'./some/' + 'example.js'`);
     const transformedRequire1 = babel.transform("var SomeExample = require('~/some/' + 'example.js');", {
       plugins: [BabelRootImportPlugin]
     });
 
     expect(transformedRequire1.code).to.contain(targetRequire1);
 
-    const targetRequire2 = slash(`${process.cwd()}/some/' + 'other' + 'example.js`);
+    const targetRequire2 = slash(`'./some/' + 'other' + 'example.js'`);
     const transformedRequire2 = babel.transform("var SomeExample = require('~/some/' + 'other' + 'example.js');", {
       plugins: [BabelRootImportPlugin]
     });
@@ -194,7 +194,7 @@ describe('Babel Root Import - Plugin', () => {
   });
 
   it('does not transform a multipart require path with variable at the beginning', () => {
-    const targetRequire = slash(`${process.cwd()}/some' + '/example.js`);
+    const targetRequire = slash(`/some' + '/example.js`);
     const transformedRequire = babel.transform("var some = '~/';var SomeExample = require(some+ '/example.js');", {
       plugins: [BabelRootImportPlugin]
     });


### PR DESCRIPTION
I had to cover several use cases since `state.file.opts.filename` behaves different depending on the app invoking it:
- webpack sends absolute paths (like `/users/foo/bar/baz.js`)
- babel-cli sends relative paths from the folder where you run the command (i.e.: `src/foo`) 

fixes #14 