### PR TITLE
Proposed fix for issue #46 

### DIFF
--- a/plugin/helper.js
+++ b/plugin/helper.js
@@ -32,13 +32,11 @@ export const transformRelativeToRootPath = (importPath, rootPathSuffix, rootPath
     const absolutePath = `${rootPathSuffix ? rootPathSuffix : ''}/${withoutRootPathPrefix}`;
     let sourcePath = sourceFile.substring(0, sourceFile.lastIndexOf('/'));
 
-    // if the path is an absolute path (webpack sends '/Users/foo/bar/baz.js' here)
-    if (sourcePath.indexOf('/') === 0) {
-      sourcePath = sourcePath.substring(root.length + 1);
+    if (!path.isAbsolute(sourcePath)) {
+      sourcePath = "/" + sourcePath;
     }
 
-    let relativePath = slash(path.relative(`/${sourcePath}`, absolutePath));
-
+    let relativePath = slash(path.relative(sourcePath, absolutePath));
     // if file is located in the same folder
     if (relativePath.indexOf('../') !== 0) {
       relativePath = './' + relativePath;

--- a/test/helper.spec.js
+++ b/test/helper.spec.js
@@ -13,6 +13,12 @@ describe('helper#transformRelativeToRootPath', () => {
     expect(result).to.equal(rootPath);
   });
 
+  it('transforms given Windows-style path relative path', () => {
+    const rootPath = slash(`./path`);
+    const result = transformRelativeToRootPath('~/some/path', '', '~', 'C:/some/file.js');
+    expect(result).to.equal(rootPath);
+  });
+
   it('throws error if no string is passed', () => {
     expect(() => {
       transformRelativeToRootPath();


### PR DESCRIPTION
https://github.com/michaelzoidl/babel-root-import/issues/46 

Inverted absolute path check, prepending slash if not absolute. Unsure why there was initially a strip of the slash followed by a prepend in the path.relative call, so may have missed something. 

Added Windows-style path test case.