### PR TITLE
Fix for windows root paths

### DIFF
--- a/plugin/helper.js
+++ b/plugin/helper.js
@@ -33,7 +33,7 @@ export const transformRelativeToRootPath = (importPath, rootPathSuffix, rootPath
     let sourcePath = sourceFile.substring(0, sourceFile.lastIndexOf('/'));
 
     // if the path is an absolute path (webpack sends '/Users/foo/bar/baz.js' here)
-    if (sourcePath.indexOf('/') === 0) {
+    if ((sourcePath.indexOf('/') === 0)||(sourcePath.indexOf(':/') === 1)||(sourcePath.indexOf(':\\') === 1)) {
       sourcePath = sourcePath.substring(root.length + 1);
     }
 


### PR DESCRIPTION
Ignores first letter and if the second and third is :/ or :\ (depends on windows version)
It would assume that there's a [letter]:/ or [letter]:\ and treat it as a root path, otherwise it will treat it as a relative path.

Fixes issues for me after updating to 4.1.1