### PR TITLE
Allow Relative Paths to use ../

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ You can supply an array of the above. The plugin will try each prefix/suffix pai
     }, {
       "rootPathPrefix": "@",
       "rootPathSuffix": "other-src/js"
+    }, {
+      "rootPathPrefix": "#",
+      "rootPathSuffix": "../../src/in/parent" // since we suport relative paths you can also go into a parent directory
     }]]
   ]
 }
@@ -106,8 +109,11 @@ Webpack delivers a similar feature, if you just want to prevent end-less import 
 [READ MORE](http://xabikos.com/2015/10/03/Webpack-aliases-and-relative-paths/)
 
 ## Change Log
+#### 4.1.4 - 2016-11-15
+- Improve support for relative paths (e.g. referencing parent folders via ../) (thanks to [@Hizoul](https://github.com/hizoul))
+
 #### 4.1.3 - 2016-09-14
-- Support paths (thanks to [@sivael](https://github.com/sivael) 
+- Support paths (thanks to [@sivael](https://github.com/sivael))
 
 #### 4.1.0 - 2016-08-20
 - Use relative paths instead of absolute ones (thanks to [@nescalante](https://github.com/nescalante))

--- a/plugin/helper.js
+++ b/plugin/helper.js
@@ -29,18 +29,15 @@ export const transformRelativeToRootPath = (importPath, rootPathSuffix, rootPath
       withoutRootPathPrefix = importPath.substring(2, importPath.length);
     }
 
-    let absolutePath = `${rootPathSuffix ? rootPathSuffix : './'}/${withoutRootPathPrefix}`;
+    const absolutePath = path.resolve(`${rootPathSuffix ? rootPathSuffix : './'}/${withoutRootPathPrefix}`);
     let sourcePath = sourceFile.substring(0, sourceFile.lastIndexOf('/'));
 
     // if the path is an absolute path (webpack sends '/Users/foo/bar/baz.js' here)
-    if ((sourcePath.indexOf('/') === 0)||(sourcePath.indexOf(':/') === 1)||(sourcePath.indexOf(':\\') === 1)) {
+    if (sourcePath.indexOf('/') === 0 || sourcePath.indexOf(':/') === 1 || sourcePath.indexOf(':\\') === 1) {
       sourcePath = sourcePath.substring(root.length + 1);
     }
 
-    if (absolutePath.charAt(0) !== '/') {
-      absolutePath = path.resolve(absolutePath);
-      sourcePath = path.resolve(sourcePath);
-    }
+    sourcePath = path.resolve(sourcePath);
 
     let relativePath = slash(path.relative(sourcePath, absolutePath));
 

--- a/plugin/helper.js
+++ b/plugin/helper.js
@@ -29,7 +29,7 @@ export const transformRelativeToRootPath = (importPath, rootPathSuffix, rootPath
       withoutRootPathPrefix = importPath.substring(2, importPath.length);
     }
 
-    const absolutePath = `${rootPathSuffix ? rootPathSuffix : ''}/${withoutRootPathPrefix}`;
+    const absolutePath = `${rootPathSuffix ? rootPathSuffix : './'}/${withoutRootPathPrefix}`;
     let sourcePath = sourceFile.substring(0, sourceFile.lastIndexOf('/'));
 
     // if the path is an absolute path (webpack sends '/Users/foo/bar/baz.js' here)
@@ -37,7 +37,12 @@ export const transformRelativeToRootPath = (importPath, rootPathSuffix, rootPath
       sourcePath = sourcePath.substring(root.length + 1);
     }
 
-    let relativePath = slash(path.relative(`/${sourcePath}`, absolutePath));
+    if (absolutePath.charAt(0) !== '/') {
+      absolutePath = path.resolve(absolutePath);
+      sourcePath = path.resolve(sourcePath);
+    }
+
+    let relativePath = slash(path.relative(sourcePath, absolutePath));
 
     // if file is located in the same folder
     if (relativePath.indexOf('../') !== 0) {
@@ -47,18 +52,6 @@ export const transformRelativeToRootPath = (importPath, rootPathSuffix, rootPath
     // if the entry has a slash, keep it
     if (importPath[importPath.length - 1] === '/') {
       relativePath += '/';
-    }
-
-    // if the entry is a realtive path that goes up in hierarchy add missing .. statements e.g. ../shared
-    const pathParts = absolutePath.split('/');
-    for (let partIterator = 0; partIterator < pathParts.length; partIterator++) {
-      if (pathParts[partIterator] === '..') {
-        relativePath = `../${relativePath}`;
-      } else {
-        if (pathParts[partIterator].length > 0) {
-          break; // First String will be empty and would cause for loop to quit
-        }
-      }
     }
 
     return relativePath;

--- a/plugin/helper.js
+++ b/plugin/helper.js
@@ -49,6 +49,18 @@ export const transformRelativeToRootPath = (importPath, rootPathSuffix, rootPath
       relativePath += '/';
     }
 
+    // if the entry is a realtive path that goes up in hierarchy add missing .. statements e.g. ../shared
+    const pathParts = absolutePath.split('/');
+    for (let partIterator = 0; partIterator < pathParts.length; partIterator++) {
+      if (pathParts[partIterator] === '..') {
+        relativePath = `../${relativePath}`;
+      } else {
+        if (pathParts[partIterator].length > 0) {
+          break; // First String will be empty and would cause for loop to quit
+        }
+      }
+    }
+
     return relativePath;
   }
 

--- a/plugin/helper.js
+++ b/plugin/helper.js
@@ -29,7 +29,7 @@ export const transformRelativeToRootPath = (importPath, rootPathSuffix, rootPath
       withoutRootPathPrefix = importPath.substring(2, importPath.length);
     }
 
-    const absolutePath = `${rootPathSuffix ? rootPathSuffix : './'}/${withoutRootPathPrefix}`;
+    let absolutePath = `${rootPathSuffix ? rootPathSuffix : './'}/${withoutRootPathPrefix}`;
     let sourcePath = sourceFile.substring(0, sourceFile.lastIndexOf('/'));
 
     // if the path is an absolute path (webpack sends '/Users/foo/bar/baz.js' here)

--- a/plugin/index.js
+++ b/plugin/index.js
@@ -9,9 +9,8 @@ const replacePrefix = (path, opts = [], sourceFile) => {
     const option = options[i];
 
     if (option.rootPathSuffix && typeof option.rootPathSuffix === 'string') {
-      rootPathSuffix = `/${option.rootPathSuffix.replace(/^(\/)|(\/)$/g, '')}`;
+      rootPathSuffix = option.rootPathSuffix;
     }
-
     if (option.rootPathPrefix && typeof option.rootPathPrefix === 'string') {
       rootPathPrefix = option.rootPathPrefix;
     } else {

--- a/test/helper.spec.js
+++ b/test/helper.spec.js
@@ -1,5 +1,6 @@
 import {hasRootPathPrefixInString, transformRelativeToRootPath} from '../plugin/helper';
 import slash from 'slash';
+import path from 'path';
 
 describe('helper#transformRelativeToRootPath', () => {
   it('returns a string', () => {
@@ -8,9 +9,27 @@ describe('helper#transformRelativeToRootPath', () => {
   });
 
   it('transforms given path relative path', () => {
-    const rootPath = slash(`./path`);
+    const rootPath = slash('./path');
     const result = transformRelativeToRootPath('~/some/path', '', '~', 'some/file.js');
     expect(result).to.equal(rootPath);
+  });
+
+  it('considers .. in relative path', () => {
+    const rootPath = slash('./path');
+    const result = transformRelativeToRootPath('~/util', '../shared', '~', 'test.js');
+    expect(result).to.not.equal(`${path.resolve('../shared')}/util/test.js`);
+  });
+
+  it('considers multiple .. in relative path', () => {
+    const rootPath = slash('./path');
+    const result = transformRelativeToRootPath('~/util', '../../../shared', '~', 'test.js');
+    expect(result).to.not.equal(`${path.resolve('../../../shared')}/util/test.js`);
+  });
+
+  it('stops adding .. after the first one has been reached', () => {
+    const rootPath = slash('./path');
+    const result = transformRelativeToRootPath('~/util', '../shared/test/../test', '~', 'test.js');
+    expect(result).to.not.equal(`${path.resolve('../shared')}/util/test/../test/test.js`);
   });
 
   it('throws error if no string is passed', () => {

--- a/test/helper.spec.js
+++ b/test/helper.spec.js
@@ -15,19 +15,16 @@ describe('helper#transformRelativeToRootPath', () => {
   });
 
   it('considers .. in relative path', () => {
-    const rootPath = slash('./path');
     const result = transformRelativeToRootPath('~/util', '../shared', '~', 'test.js');
     expect(result).to.not.equal(`${path.resolve('../shared')}/util/test.js`);
   });
 
   it('considers multiple .. in relative path', () => {
-    const rootPath = slash('./path');
     const result = transformRelativeToRootPath('~/util', '../../../shared', '~', 'test.js');
     expect(result).to.not.equal(`${path.resolve('../../../shared')}/util/test.js`);
   });
 
   it('stops adding .. after the first one has been reached', () => {
-    const rootPath = slash('./path');
     const result = transformRelativeToRootPath('~/util', '../shared/test/../test', '~', 'test.js');
     expect(result).to.not.equal(`${path.resolve('../shared')}/util/test/../test/test.js`);
   });

--- a/test/plugin.spec.js
+++ b/test/plugin.spec.js
@@ -221,7 +221,7 @@ describe('Babel Root Import - Plugin', () => {
       plugins
     });
 
-    const targetRequire2 = slash(`../.././some2/custom/root/some/example.js`);
+    const targetRequire2 = slash(`../../some2/custom/root/some/example.js`);
     const transformedImport2 = babel.transform("import SomeExample from '@/some/example.js';", {
       plugins
     });

--- a/test/plugin.spec.js
+++ b/test/plugin.spec.js
@@ -201,4 +201,37 @@ describe('Babel Root Import - Plugin', () => {
 
     expect(transformedRequire.code).to.not.contain(targetRequire);
   });
+
+  it('Considers .. Statements in relative Paths', () => {
+    const plugins = [[
+      BabelRootImportPlugin, [{
+        rootPathPrefix: '~',
+        rootPathSuffix: 'some1/custom/root'
+      }, {
+        rootPathPrefix: '@',
+        rootPathSuffix: '../../some2/custom/../custom/root'
+      }]
+    ]]
+
+    const targetRequire1 = slash(`/some1/custom/root/some/example.js`);
+    const transformedImport1 = babel.transform("import SomeExample from '~/some/example.js';", {
+      plugins
+    });
+    const transformedRequire1 = babel.transform("var SomeExample = require('~/some/example.js');", {
+      plugins
+    });
+
+    const targetRequire2 = slash(`../.././some2/custom/root/some/example.js`);
+    const transformedImport2 = babel.transform("import SomeExample from '@/some/example.js';", {
+      plugins
+    });
+    const transformedRequire2 = babel.transform("var SomeExample = require('@/some/example.js');", {
+      plugins
+    });
+
+    expect(transformedImport1.code).to.contain(targetRequire1);
+    expect(transformedRequire1.code).to.contain(targetRequire1);
+    expect(transformedImport2.code).to.contain(targetRequire2);
+    expect(transformedRequire2.code).to.contain(targetRequire2);
+  });
 });


### PR DESCRIPTION
Currently if the rootPathSuffix contains '..' it will ignore it because path.relative does not handle it correctly.
I also tried 'src/../shared' but path.resolve also did not resolve that correctly.
So I implemented a workaround, that checks if the path starts with '..' and adds them to the newly calculated path.
Here is an example .babelrc configuration that will not work with the current version, but will work after my commited changes.
```javascript
{
  "plugins": [
    ["babel-root-import",  [{
      "rootPathPrefix": "~",
      "rootPathSuffix": "src"
    }, {
      "rootPathPrefix": "@",
      "rootPathSuffix": "../shared"
    }]]
  ]]
  ]
}

// Now you can use the plugin like:
import foo from '@/my-file';
import bar from '~/my-other-file';
```